### PR TITLE
Add tf 0.12.9 0.13.6 0.14.3 for migrations

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -1,5 +1,5 @@
 // Include this shared CI repository to load script helpers and libraries.
-library identifier: 'vapor@0.2.0', retriever: modernSCM(
+library identifier: 'vapor@1.0.3', retriever: modernSCM(
         [$class: 'GitSCMSource',
         remote: 'https://github.com/vapor-ware/ci-shared.git',
         credentialsId: 'vio-bot-gh'])

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,14 +3,15 @@ ADD https://github.com/vapor-ware/sctl/releases/download/1.4.2/sctl_1.4.2_Linux_
 WORKDIR /tmp
 RUN tar xvfz sctl.tar.gz
 
-FROM runatlantis/atlantis:v0.14.0
+FROM runatlantis/atlantis:v0.16.0
 COPY --from=0 /tmp/sctl /usr/local/bin/sctl
 
 # install terraform binaries
-ENV DEFAULT_TERRAFORM_VERSION=0.12.29
+ENV NEEDED_TERRAFORM_VERSIONS="0.12.29 0.13.6 0.14.3"
+ENV DEFAULT_TERRAFORM_VERSION=0.14.3
 
 # In the official Atlantis image we only have the latest of each Terraform version.
-RUN AVAILABLE_TERRAFORM_VERSIONS="${DEFAULT_TERRAFORM_VERSION}" && \
+RUN AVAILABLE_TERRAFORM_VERSIONS="${NEEDED_TERRAFORM_VERSIONS}" && \
     rm -f /usr/local/bin/terraform && \
     for VERSION in ${AVAILABLE_TERRAFORM_VERSIONS}; do \
         curl -LOs https://releases.hashicorp.com/terraform/${VERSION}/terraform_${VERSION}_linux_amd64.zip && \


### PR DESCRIPTION
We fell behind a couple tf versions, so we need an Atlantis release to bridge the gap with all 3 versions necessary to run the backend migrations.

  See the following documents for supporting upgrade instructions that
  this pr addresses:

  - https://www.terraform.io/upgrade-guides/0-14.html
  - https://www.terraform.io/upgrade-guides/0-13.html

Also upgrades Atlantis from 0.14 to 0.16

- https://github.com/runatlantis/atlantis/releases

Closes https://github.com/vapor-ware/cloud-ops/issues/841 with Atlantis 0.16

Note: 0.14.5 is the latest terraform, Atlantis 0.16.0 is only confirmed to work with terraform 0.14.3, so that's what we added.