### PR TITLE
Use ci-shared release 1.18.0

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -1,5 +1,5 @@
 // Include this shared CI repository to load script helpers and libraries.
-library identifier: 'vapor@1.0.3', retriever: modernSCM(
+library identifier: 'vapor@1.18.0', retriever: modernSCM(
         [$class: 'GitSCMSource',
         remote: 'https://github.com/vapor-ware/ci-shared.git',
         credentialsId: 'vio-bot-gh'])


### PR DESCRIPTION
- Enable Clair image scanner

In Jenkins build job logs it dumps the image scan summary with vulnerabilities something like the following:

Image: docker.io/vaporio/atlantis:ci-shared-1.18.0.1
Unknown: 3
Negligible: 0
Low: 3
Medium: 19
High: 0
Critical: 0
Defcon1: 0```

One of the steps in build prints the HTML report link with all the details of CVE's present in the image.
https://storage.cloud.google.com/vapor-clair-reports/jenkins-vapor-ware-atlantis-ci-shared%252F1.18.0-1/html/analysis-vaporio-atlantis-ci-shared-1.18.0.1.html?authuser=1